### PR TITLE
bugfix: printclauses had no newline.

### DIFF
--- a/Resolution/coreprint.jl
+++ b/Resolution/coreprint.jl
@@ -57,6 +57,7 @@ end
 function printclauses(core)
   for cid in sort(collect(keys(core.cdb)))
     printclause(cid, core)
+println()
   end
 end
 


### PR DESCRIPTION
added it

	modified:   coreprint.jl